### PR TITLE
change from mysql to mariadb

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ sudo apt-get update
 echo "installing required programs"
 sudo apt-get install kdebase-runtime libqt4-dev build-essential g++ cmake gettext libqt4-sql-mysql kdelibs5-dev -y
 echo "installing mysql"
-sudo apt-get install mysql-client mysql-server -y
+sudo apt-get install mariadb-client mariadb-server -y
 echo "begin build"
 mkdir build
 cd build


### PR DESCRIPTION
With the new raspbian (buster) mysql is no longer supported.
This fix now installs mariadb instead