### PR TITLE
[codex] Fix Qt autogen configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC OFF)
 set(CMAKE_AUTORCC ON)
 
-find_package(Qt5 REQUIRED COMPONENTS Widgets Sql PrintSupport)
+find_package(Qt5 REQUIRED COMPONENTS Widgets Sql PrintSupport Svg)
 find_package(
   KF5 REQUIRED
   COMPONENTS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(
   KF5 REQUIRED
   COMPONENTS
     CoreAddons
+    Completion
     ConfigWidgets
     Config
     I18n

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ include(KDECMakeSettings)
 include(KDECompilerSettings NO_POLICY_SCOPE)
 
 set(CMAKE_AUTOMOC ON)
-set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOUIC OFF)
 set(CMAKE_AUTORCC ON)
 
 find_package(Qt5 REQUIRED COMPONENTS Widgets Sql PrintSupport)

--- a/INSTALL
+++ b/INSTALL
@@ -37,7 +37,7 @@ Now that everything is up to date, we can install the needed KDE Frameworks 5 an
   we need for the compile and install:
   
   sudo apt-get install build-essential cmake extra-cmake-modules gettext g++ qtbase5-dev qttools5-dev \
-    libqt5sql5-mysql libkf5config-dev libkf5configwidgets-dev libkf5i18n-dev \
+    libqt5sql5-mysql libkf5completion-dev libkf5config-dev libkf5configwidgets-dev libkf5i18n-dev \
     libkf5kio-dev libkf5notifications-dev libkf5plotting-dev libkf5widgetsaddons-dev libkf5xmlgui-dev
   
 For a spanish KDE app: 

--- a/INSTALL
+++ b/INSTALL
@@ -37,7 +37,7 @@ Now that everything is up to date, we can install the needed KDE Frameworks 5 an
   we need for the compile and install:
   
   sudo apt-get install build-essential cmake extra-cmake-modules gettext g++ qtbase5-dev qttools5-dev \
-    libqt5sql5-mysql libkf5completion-dev libkf5config-dev libkf5configwidgets-dev libkf5i18n-dev \
+    libqt5sql5-mysql libqt5svg5-dev libkf5completion-dev libkf5config-dev libkf5configwidgets-dev libkf5i18n-dev \
     libkf5kio-dev libkf5notifications-dev libkf5plotting-dev libkf5widgetsaddons-dev libkf5xmlgui-dev
   
 For a spanish KDE app: 

--- a/dataAccess/azahar.cpp
+++ b/dataAccess/azahar.cpp
@@ -5106,7 +5106,3 @@ qulonglong  Azahar::insertCreditHistory(const CreditHistoryInfo &info)
     else result = query.lastInsertId().toULongLong();
     return result;
 }
-
-
-
-#include "azahar.moc"

--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,7 @@ sudo apt-get install \
   extra-cmake-modules \
   gettext \
   g++ \
+  libkf5completion-dev \
   libkf5config-dev \
   libkf5configwidgets-dev \
   libkf5i18n-dev \

--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,7 @@ sudo apt-get install \
   libkf5widgetsaddons-dev \
   libkf5xmlgui-dev \
   libqt5sql5-mysql \
+  libqt5svg5-dev \
   qtbase5-dev \
   qttools5-dev \
   -y

--- a/iotstock/src/CMakeLists.txt
+++ b/iotstock/src/CMakeLists.txt
@@ -78,6 +78,7 @@ endif()
 
 target_link_libraries(iotstock
   KF5::CoreAddons
+  KF5::Completion
   KF5::ConfigCore
   KF5::ConfigWidgets
   KF5::I18n

--- a/iotstock/src/CMakeLists.txt
+++ b/iotstock/src/CMakeLists.txt
@@ -89,6 +89,7 @@ target_link_libraries(iotstock
   KF5::XmlGui
   Qt5::PrintSupport
   Qt5::Sql
+  Qt5::Svg
   Qt5::Widgets
 )
 

--- a/iotstock/src/clienteditor.cpp
+++ b/iotstock/src/clienteditor.cpp
@@ -106,5 +106,3 @@ void ClientEditor::checkName()
         enableButtonOk(true);
   }
 }
-
-#include "clienteditor.moc"

--- a/iotstock/src/iotstock.cpp
+++ b/iotstock/src/iotstock.cpp
@@ -538,5 +538,3 @@ void iotstock::salir()
 {
   qApp->quit();
 }
-
-#include "iotstock.moc"

--- a/iotstock/src/iotstock.cpp
+++ b/iotstock/src/iotstock.cpp
@@ -31,15 +31,15 @@
 #include <QDesktopWidget>
 
 #include "iconutils.h"
-#include <kmenubar.h>
-#include <kstatusbar.h>
-#include <kconfigdialog.h>
+#include <QMenuBar>
+#include <QStatusBar>
+#include <KConfigDialog>
 //#include <kio/netaccess.h>
 // #include <QFileDialog>
-#include <kactioncollection.h>
+#include <KActionCollection>
 #include <QAction>
 #include <QLocale>
-#include <kled.h>
+#include <KLed>
 #include "pathutils.h"
 
 iotstock::iotstock()

--- a/iotstock/src/iotstock.h
+++ b/iotstock/src/iotstock.h
@@ -26,7 +26,7 @@
 #include "ui_prefs_db.h"
 #include "ui_pref_printers.h"
 
-#include <kxmlguiwindow.h>
+#include <KXmlGuiWindow>
 
 #include <QDragEnterEvent>
 #include <QDropEvent>

--- a/iotstock/src/iotstockview.cpp
+++ b/iotstock/src/iotstockview.cpp
@@ -4327,5 +4327,3 @@ void iotstockView::categoriesOnSelected(const QModelIndex &index)
         delete myDb;
     }
 }
-
-#include "iotstockview.moc"

--- a/iotstock/src/iotstockview.cpp
+++ b/iotstock/src/iotstockview.cpp
@@ -1,3 +1,6 @@
+#include <QMarginsF>
+#include <QPageLayout>
+#include <QPageSize>
 /**************************************************************************
  *   Copyright © 2007-2012 by Miguel Chavez Gamboa                         *
  *   hiramvillarreal.ap@gmail.com                                          *
@@ -210,7 +213,8 @@ void iotstockView::login(){
   }
   if (!db.isOpen()) {
     QString details = db.lastError().text();
-    KNotification *notify = new KNotification(i18n("Unable to connect to the database"), this);
+    KNotification *notify = new KNotification(i18n("Unable to connect to the database"));
+    notify->setWidget(this);
     notify->setText(details);
     QPixmap pixmap = themedPixmap("dialog-error",22); //NOTE: This does not works
     notify->setPixmap(pixmap);
@@ -625,7 +629,7 @@ void iotstockView::adjustProductsTable()
 {
   QSize size = ui_mainview.productsViewAlt->size();
   int portion = size.width()/11;
-  ui_mainview.productsViewAlt->horizontalHeader()->setResizeMode(QHeaderView::Interactive);
+  ui_mainview.productsViewAlt->horizontalHeader()->setSectionResizeMode(QHeaderView::Interactive);
   ui_mainview.productsViewAlt->horizontalHeader()->resizeSection(0, portion*1.5); // CODE
   ui_mainview.productsViewAlt->horizontalHeader()->resizeSection(1, portion*3.5); //Name
   ui_mainview.productsViewAlt->horizontalHeader()->resizeSection(2, portion); //Price
@@ -640,7 +644,7 @@ void iotstockView::adjustOffersTable()
 {
   QSize size = ui_mainview.tableBrowseOffers->size();
   int portion = size.width()/6;
-  ui_mainview.tableBrowseOffers->horizontalHeader()->setResizeMode(QHeaderView::Interactive);
+  ui_mainview.tableBrowseOffers->horizontalHeader()->setSectionResizeMode(QHeaderView::Interactive);
   ui_mainview.tableBrowseOffers->horizontalHeader()->resizeSection(1, portion*1.5); //PRODUCT DESC
   ui_mainview.tableBrowseOffers->horizontalHeader()->resizeSection(2, portion); //Qty
   ui_mainview.tableBrowseOffers->horizontalHeader()->resizeSection(3, portion); //Date start
@@ -3339,8 +3343,8 @@ void iotstockView::printGralEndOfDay()
         qDebug()<<fn;
         
         printer.setOutputFileName(fn);
-        printer.setPageMargins(0,0,0,0,QPrinter::Millimeter);
-        printer.setPaperSize(QSizeF(72,200), QPrinter::Millimeter); //setting small ticket paper size. 72mm x 200mm
+        printer.setPageMargins(QMarginsF(), QPageLayout::Millimeter);
+        printer.setPageSize(QPageSize(QSizeF(72,200), QPageSize::Millimeter)); //setting small ticket paper size. 72mm x 200mm
         
         PrintCUPS::printSmallEndOfDay(pdInfo, printer);
     }
@@ -3385,7 +3389,8 @@ void iotstockView::printEndOfDay()
     if (transactionsList.count() < 1) {
       //hey, if there are no transactions, why print it?
       qDebug()<<"Nothing to print!";
-      KNotification *notify = new KNotification(i18n("No transactions to print!"), this);
+      KNotification *notify = new KNotification(i18n("No transactions to print!"));
+      notify->setWidget(this);
       notify->setText(i18n("No transactions for  terminal #%1 for today.", terminalNum));
       QPixmap pixmap = themedPixmap("dialog-warning",22);
       notify->setPixmap(pixmap);
@@ -3471,8 +3476,8 @@ void iotstockView::printEndOfDay()
           qDebug()<<fn;
           
           printer.setOutputFileName(fn);
-          printer.setPageMargins(0,0,0,0,QPrinter::Millimeter);
-          printer.setPaperSize(QSizeF(72,200), QPrinter::Millimeter); //setting small ticket paper size. 72mm x 200mm
+          printer.setPageMargins(QMarginsF(), QPageLayout::Millimeter);
+          printer.setPageSize(QPageSize(QSizeF(72,200), QPageSize::Millimeter)); //setting small ticket paper size. 72mm x 200mm
           
           PrintCUPS::printSmallEndOfDay(pdInfo, printer);
       }
@@ -3580,8 +3585,8 @@ void iotstockView::printEndOfMonth()
         qDebug()<<fn;
         
         printer.setOutputFileName(fn);
-        printer.setPageMargins(0,0,0,0,QPrinter::Millimeter);
-        printer.setPaperSize(QSizeF(72,200), QPrinter::Millimeter); //setting small ticket paper size. 72mm x 200mm
+        printer.setPageMargins(QMarginsF(), QPageLayout::Millimeter);
+        printer.setPageSize(QPageSize(QSizeF(72,200), QPageSize::Millimeter)); //setting small ticket paper size. 72mm x 200mm
         
         PrintCUPS::printSmallEndOfDay(pdInfo, printer);
     }
@@ -3661,8 +3666,8 @@ void iotstockView::printLowStockProducts()
         qDebug()<<fn;
         
         printer.setOutputFileName(fn);
-        printer.setPageMargins(0,0,0,0,QPrinter::Millimeter);
-        printer.setPaperSize(QSizeF(72,200), QPrinter::Millimeter); //setting small ticket paper size. 72mm x 200mm
+        printer.setPageMargins(QMarginsF(), QPageLayout::Millimeter);
+        printer.setPageSize(QPageSize(QSizeF(72,200), QPageSize::Millimeter)); //setting small ticket paper size. 72mm x 200mm
         
         PrintCUPS::printSmallLowStockReport(plInfo, printer);
     }
@@ -3742,8 +3747,8 @@ void iotstockView::printStock()
             qDebug()<<fn;
             
             printer.setOutputFileName(fn);
-            printer.setPageMargins(0,0,0,0,QPrinter::Millimeter);
-            printer.setPaperSize(QSizeF(72,200), QPrinter::Millimeter); //setting small ticket paper size. 72mm x 200mm
+            printer.setPageMargins(QMarginsF(), QPageLayout::Millimeter);
+            printer.setPageSize(QPageSize(QSizeF(72,200), QPageSize::Millimeter)); //setting small ticket paper size. 72mm x 200mm
             
             PrintCUPS::printSmallLowStockReport(plInfo, printer);
         }
@@ -3822,8 +3827,8 @@ void iotstockView::printSoldOutProducts()
         qDebug()<<fn;
         
         printer.setOutputFileName(fn);
-        printer.setPageMargins(0,0,0,0,QPrinter::Millimeter);
-        printer.setPaperSize(QSizeF(72,200), QPrinter::Millimeter); //setting small ticket paper size. 72mm x 200mm
+        printer.setPageMargins(QMarginsF(), QPageLayout::Millimeter);
+        printer.setPageSize(QPageSize(QSizeF(72,200), QPageSize::Millimeter)); //setting small ticket paper size. 72mm x 200mm
         
         PrintCUPS::printSmallLowStockReport(plInfo, printer);
     }
@@ -3998,8 +4003,8 @@ void iotstockView::printSelectedBalance()
             qDebug()<<fn;
             
             printer.setOutputFileName(fn);
-            printer.setPageMargins(0,0,0,0,QPrinter::Millimeter);
-            printer.setPaperSize(QSizeF(72,200), QPrinter::Millimeter); //setting small ticket paper size. 72mm x 200mm
+            printer.setPageMargins(QMarginsF(), QPageLayout::Millimeter);
+            printer.setPageSize(QPageSize(QSizeF(72,200), QPageSize::Millimeter)); //setting small ticket paper size. 72mm x 200mm
             
             PrintCUPS::printSmallBalance(pbInfo, printer);
         }

--- a/iotstock/src/iotstockview.cpp
+++ b/iotstock/src/iotstockview.cpp
@@ -67,8 +67,8 @@
 #include <KLocalizedString>
 #include <QFileDialog>
 #include "iconutils.h"
-#include <kmessagebox.h>
-#include <kactioncollection.h>
+#include <KMessageBox>
+#include <KActionCollection>
 #include <QAction>
 #include "pathutils.h"
 

--- a/iotstock/src/iotstockview.cpp
+++ b/iotstock/src/iotstockview.cpp
@@ -72,10 +72,10 @@
 #include <QAction>
 #include "pathutils.h"
 
-#include <kplotobject.h>
-#include <kplotwidget.h>
-#include <kplotaxis.h>
-#include <kplotpoint.h>
+#include <KPlotObject>
+#include <KPlotWidget>
+#include <KPlotAxis>
+#include <KPlotPoint>
 
 #include <KNotification>
 
@@ -303,7 +303,7 @@ void iotstockView::setupSignalConnections()
 
   connect(timerCheckDb, SIGNAL(timeout()), this, SLOT(checkDBStatus()));
   connect(timerUpdateGraphs, SIGNAL(timeout()), this, SLOT(updateGraphs()));
-  connect(ui_mainview.offersDateEditor, SIGNAL(changed(const QDate &)), this, SLOT(setOffersFilter()));
+  connect(ui_mainview.offersDateEditor, SIGNAL(dateChanged(const QDate &)), this, SLOT(setOffersFilter()));
 
   connect(this, SIGNAL(signalAdminLoggedOn()),  SLOT( enableUI()));
   connect(this, SIGNAL(signalAdminLoggedOff()),  SLOT( disableUI()));
@@ -321,7 +321,7 @@ void iotstockView::setupSignalConnections()
   connect(ui_mainview.rbTransFilterByPaidCredit, SIGNAL(toggled(bool)), this, SLOT( setTransactionsFilter()) );
   connect(ui_mainview.comboCardTypes, SIGNAL(currentIndexChanged(int)), this, SLOT( setTransactionsFilter()) );
   connect(ui_mainview.rbTransFilterByDate, SIGNAL(toggled(bool)), this, SLOT( setTransactionsFilter()) );
-  connect(ui_mainview.transactionsDateEditor, SIGNAL( changed(const QDate &) ), SLOT(setTransactionsFilter()));
+  connect(ui_mainview.transactionsDateEditor, SIGNAL( dateChanged(const QDate &) ), SLOT(setTransactionsFilter()));
   connect(ui_mainview.rbTransFilterByUser, SIGNAL(toggled(bool)), this, SLOT( setTransactionsFilter()) );
   connect(ui_mainview.editTransUsersFilter,SIGNAL(textEdited( const QString &)), this, SLOT( setTransactionsFilter()) );
   connect(ui_mainview.rbTransFilterByClient, SIGNAL(toggled(bool)), this, SLOT( setTransactionsFilter()) );
@@ -344,7 +344,7 @@ void iotstockView::setupSignalConnections()
   connect(ui_mainview.rbBalancesFilterByUser, SIGNAL(toggled(bool)), this, SLOT( setBalancesFilter()) );
   connect(ui_mainview.rbBalancesFilterByCashInLess, SIGNAL(toggled(bool)), this, SLOT( setBalancesFilter()) );
   connect(ui_mainview.rbBalancesFilterByCashInGrater, SIGNAL(toggled(bool)), this, SLOT( setBalancesFilter()) );
-  connect(ui_mainview.editBalancesFilterByDate, SIGNAL( changed(const QDate &) ), SLOT(setBalancesFilter()));
+  connect(ui_mainview.editBalancesFilterByDate, SIGNAL( dateChanged(const QDate &) ), SLOT(setBalancesFilter()));
   connect(ui_mainview.rbBalancesFilgerByTerminalNum, SIGNAL(toggled(bool)), this, SLOT( setBalancesFilter()) );
   connect(ui_mainview.editBalancesFilterByVendor,SIGNAL(textEdited( const QString &)), this, SLOT( setBalancesFilter()) );
   connect(ui_mainview.editBalancesFilterByCasInLess ,SIGNAL(valueChanged ( double ) ), this, SLOT( setBalancesFilter()) );
@@ -398,7 +398,7 @@ void iotstockView::setupSignalConnections()
   connect(ui_mainview.rbSOByStatusReady, SIGNAL(toggled(bool)), this, SLOT( setSpecialOrdersFilter()) );
   connect(ui_mainview.rbSOByStatusDelivered, SIGNAL( toggled(bool) ), SLOT(setSpecialOrdersFilter()));
   connect(ui_mainview.rbSOByStatusCancelled, SIGNAL(toggled(bool)), this, SLOT( setSpecialOrdersFilter()) );
-  connect(ui_mainview.datePicker,SIGNAL(changed(const QDate &)), this, SLOT( setSpecialOrdersFilter()) );
+  connect(ui_mainview.datePicker,SIGNAL(dateChanged(const QDate &)), this, SLOT( setSpecialOrdersFilter()) );
 
 
   connect(ui_mainview.btnAddCurrency, SIGNAL(clicked()), SLOT(createCurrency()));

--- a/iotstock/src/main.cpp
+++ b/iotstock/src/main.cpp
@@ -42,7 +42,7 @@ int main(int argc, char **argv)
         i18n("IotStock"),
         QString::fromLatin1(version),
         i18n(description),
-        KAboutData::License_GPL,
+        KAboutLicense::GPL,
         i18n("(C) 2007-2011 Miguel Chavez Gamboa"),
         QString(),
         QString(),

--- a/iotstock/src/offersdelegate.cpp
+++ b/iotstock/src/offersdelegate.cpp
@@ -82,5 +82,3 @@ QWidget *OffersDelegate::createEditor(QWidget *parent, const QStyleOptionViewIte
     return editor;
   }
 }
-
-#include "offersdelegate.moc"

--- a/iotstock/src/producteditor.cpp
+++ b/iotstock/src/producteditor.cpp
@@ -1266,10 +1266,6 @@ void ProductEditor::createNewMeasure()
         delete myDb;
     }
 }
-
-#include "producteditor.moc"
-
-
 void ProductEditorUI::on_chRise_clicked(bool checked)
 {
 

--- a/iotstock/src/promoeditor.cpp
+++ b/iotstock/src/promoeditor.cpp
@@ -193,6 +193,3 @@ void PromoEditor::setupModel()
     model->select();
   }
 }
-
-
-#include "promoeditor.moc"

--- a/iotstock/src/providerseditor.cpp
+++ b/iotstock/src/providerseditor.cpp
@@ -231,5 +231,3 @@ void ProvidersEditor::setProviderId(qulonglong id)
   m_model->setFilter(QString("provider_id=%1").arg(m_pInfo.id));
   m_model->select();
 }
-
-#include "providerseditor.moc"

--- a/iotstock/src/purchaseeditor.cpp
+++ b/iotstock/src/purchaseeditor.cpp
@@ -715,7 +715,7 @@ void PurchaseEditor::insertProduct(ProductInfo info)
       }
     }
     
-    ui->tableView->horizontalHeader()->setResizeMode(QHeaderView::Interactive);
+    ui->tableView->horizontalHeader()->setSectionResizeMode(QHeaderView::Interactive);
     ui->tableView->resizeRowsToContents();
     //totalBuy = totalBuy + info.cost*info.purchaseQty;
     //itemCount = itemCount + info.purchaseQty;

--- a/iotstock/src/purchaseeditor.cpp
+++ b/iotstock/src/purchaseeditor.cpp
@@ -953,5 +953,3 @@ void PurchaseEditor::createNewMeasure()
         delete myDb;
     }
 }
-
-#include "purchaseeditor.moc"

--- a/iotstock/src/subcategoryeditor.cpp
+++ b/iotstock/src/subcategoryeditor.cpp
@@ -173,5 +173,3 @@ void SubcategoryEditor::addNewChild()
         }// dialogType == 2
     }
 }
-
-#include "subcategoryeditor.moc"

--- a/iotstock/src/ui/editclient_widget.ui
+++ b/iotstock/src/ui/editclient_widget.ui
@@ -280,7 +280,7 @@
     </widget>
    </item>
    <item row="6" column="2" colspan="4">
-    <widget class="KDateWidget" name="sinceDatePicker" native="true">
+    <widget class="QDateEdit" name="sinceDatePicker" native="true">
      <property name="minimumSize">
       <size>
        <width>0</width>
@@ -302,11 +302,6 @@
    <class>MibitLineEdit</class>
    <extends>QLineEdit</extends>
    <header>../../mibitWidgets/mibitlineedit.h</header>
-  </customwidget>
-  <customwidget>
-   <class>KDateWidget</class>
-   <extends>QWidget</extends>
-   <header>kdatewidget.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/iotstock/src/ui/editpromo_widget.ui
+++ b/iotstock/src/ui/editpromo_widget.ui
@@ -189,7 +189,7 @@
   <customwidget>
    <class>KDatePicker</class>
    <extends>QFrame</extends>
-   <header>kdatepicker.h</header>
+   <header>KDatePicker</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/iotstock/src/ui/iotstockview_base.ui
+++ b/iotstock/src/ui/iotstockview_base.ui
@@ -2119,7 +2119,7 @@
                  </widget>
                 </item>
                 <item row="1" column="1" rowspan="2">
-                 <widget class="KDateWidget" name="editBalancesFilterByDate" native="true">
+                 <widget class="QDateEdit" name="editBalancesFilterByDate" native="true">
                   <property name="sizePolicy">
                    <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
                     <horstretch>0</horstretch>
@@ -2433,7 +2433,7 @@
                  </widget>
                 </item>
                 <item row="6" column="1">
-                 <widget class="KDateWidget" name="transactionsDateEditor" native="true">
+                 <widget class="QDateEdit" name="transactionsDateEditor" native="true">
                   <property name="sizePolicy">
                    <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
                     <horstretch>0</horstretch>
@@ -2796,7 +2796,7 @@ color:black;</string>
          </widget>
         </item>
         <item row="2" column="1">
-         <widget class="KDateWidget" name="offersDateEditor" native="true">
+         <widget class="QDateEdit" name="offersDateEditor" native="true">
           <property name="date" stdset="0">
            <date>
             <year>2009</year>
@@ -3022,7 +3022,7 @@ color:black;</string>
                </spacer>
               </item>
               <item>
-               <widget class="KDateWidget" name="datePicker" native="true"/>
+               <widget class="QDateEdit" name="datePicker" native="true"/>
               </item>
              </layout>
             </item>
@@ -3231,13 +3231,8 @@ color:black;</string>
   <customwidget>
    <class>KPlotWidget</class>
    <extends>QFrame</extends>
-   <header>kplotwidget.h</header>
+   <header>KPlotWidget</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>KDateWidget</class>
-   <extends>QWidget</extends>
-   <header>kdatewidget.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/iotstock/src/ui/promo.ui
+++ b/iotstock/src/ui/promo.ui
@@ -188,7 +188,7 @@
   <customwidget>
    <class>KDatePicker</class>
    <extends>QFrame</extends>
-   <header>kdatepicker.h</header>
+   <header>KDatePicker</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/iotstock/src/usereditor.cpp
+++ b/iotstock/src/usereditor.cpp
@@ -111,5 +111,3 @@ void UserEditor::disallowAdminChange(const bool &yes)
       ui->setDisabled(yes); //everything
     }
 }
-
-#include "usereditor.moc"

--- a/iotstock/src/usersdelegate.cpp
+++ b/iotstock/src/usersdelegate.cpp
@@ -114,5 +114,3 @@ QSize UsersDelegate::sizeHint(const QStyleOptionViewItem &optionUnused,
 {
   return QSize(170,170);
 }
-
-#include "usersdelegate.moc"

--- a/mibitWidgets/mibitdialog.h
+++ b/mibitWidgets/mibitdialog.h
@@ -51,9 +51,9 @@ class MibitDialog : public QSvgWidget
 {
 Q_OBJECT
 public:
-    MibitDialog(QWidget *parent = 0, const QString &msg = 0, const QString &file = 0, const QPixmap &icon = 0, AnimationType animation = atSlideDown );
+    MibitDialog(QWidget *parent = nullptr, const QString &msg = QString(), const QString &file = QString(), const QPixmap &icon = QPixmap(), AnimationType animation = atSlideDown );
     ~MibitDialog();
-    void showDialog( const QString &msg = 0, AnimationType animation = atSlideDown );
+    void showDialog( const QString &msg = QString(), AnimationType animation = atSlideDown );
     // Tratar de hacer un metodo similar al QDialog::getDouble()... con static
     void setSVG(const QString &file);
     void setIcon(const QPixmap &icon);

--- a/mibitWidgets/mibitfloatpanel.h
+++ b/mibitWidgets/mibitfloatpanel.h
@@ -51,7 +51,7 @@ class MibitFloatPanel : public QSvgWidget
 {
 Q_OBJECT
 public:
-    MibitFloatPanel(QWidget *parent = 0, const QString &file = 0, PanelPosition position = Top, const int &w=100, const int &h=100);
+    MibitFloatPanel(QWidget *parent = nullptr, const QString &file = QString(), PanelPosition position = Top, const int &w=100, const int &h=100);
     ~MibitFloatPanel();
     void addWidget(QWidget * widget);
     void setPosition(const PanelPosition pos);

--- a/mibitWidgets/mibitnotifier.h
+++ b/mibitWidgets/mibitnotifier.h
@@ -40,9 +40,9 @@ class MibitNotifier : public QSvgWidget
 {
 Q_OBJECT
 public:
-    MibitNotifier(QWidget *parent = 0, const QString &file = 0, const QPixmap &icon = 0, const bool &onTop= true);
+    MibitNotifier(QWidget *parent = nullptr, const QString &file = QString(), const QPixmap &icon = QPixmap(), const bool &onTop= true);
     ~MibitNotifier();
-    void showNotification( const QString &msg = 0, const int &timeToLive = 0); //timeToLive = 0 : not auto hide it.
+    void showNotification( const QString &msg = QString(), const int &timeToLive = 0); //timeToLive = 0 : not auto hide it.
     void setOnBottom(const bool &sOnBottom = true);
     void setSVG(const QString &file);
     void setIcon(const QPixmap &icon);

--- a/mibitWidgets/mibitpassworddlg.h
+++ b/mibitWidgets/mibitpassworddlg.h
@@ -52,7 +52,7 @@ class MibitPasswordDialog : public QSvgWidget
 {
 Q_OBJECT
 public:
-    MibitPasswordDialog(QWidget *parent = 0, const QString &msg = 0, const QString &file = 0, const QPixmap &icon = 0, AnimationTypeP animation = atpSlideDown );
+    MibitPasswordDialog(QWidget *parent = nullptr, const QString &msg = QString(), const QString &file = QString(), const QPixmap &icon = QPixmap(), AnimationTypeP animation = atpSlideDown );
     ~MibitPasswordDialog();
     void setSVG(const QString &file);
     void setIcon(const QPixmap &icon);
@@ -97,7 +97,7 @@ private slots:
 public slots:
     void shake();
     void wave();
-    void showDialog( const QString &msg = 0, AnimationTypeP animation = atpSlideDown );
+    void showDialog( const QString &msg = QString(), AnimationTypeP animation = atpSlideDown );
     void hideDialog();
 
 protected:

--- a/mibitWidgets/mibittip.h
+++ b/mibitWidgets/mibittip.h
@@ -57,10 +57,10 @@ class MibitTip : public QSvgWidget
 {
   Q_OBJECT
   public:
-    explicit MibitTip( QWidget *parent = 0,
+    explicit MibitTip( QWidget *parent = nullptr,
                        QWidget *partner = 0,
-                       const QString &file = 0,
-                       const QPixmap &icon = 0,
+                       const QString &file = QString(),
+                       const QPixmap &icon = QPixmap(),
                        const TipPosition &drawOn = tpBelow );
     virtual ~MibitTip();
 

--- a/printing/print-cups.h
+++ b/printing/print-cups.h
@@ -31,6 +31,7 @@
 */
 
 class QString;
+class QPrinter;
 
 class PrintCUPS {
   public:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,6 +68,7 @@ add_executable(iotpos ${iotpos_SRCS})
 
 target_link_libraries(iotpos
   KF5::CoreAddons
+  KF5::Completion
   KF5::ConfigCore
   KF5::ConfigWidgets
   KF5::I18n

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,6 +79,7 @@ target_link_libraries(iotpos
   KF5::XmlGui
   Qt5::PrintSupport
   Qt5::Sql
+  Qt5::Svg
   Qt5::Widgets
 )
 

--- a/src/dialogclientdata.cpp
+++ b/src/dialogclientdata.cpp
@@ -72,5 +72,3 @@ QString DialogClientData::getDireccion()
     QString t = ui->editDireccion->toPlainText();
     return t;
 }
-
-#include "dialogclientdata.moc"

--- a/src/inputdialog.cpp
+++ b/src/inputdialog.cpp
@@ -297,6 +297,3 @@ void InputDialog::setProductCodeReadOnly()
   productCodeEdit->setReadOnly(true);
   lineEdit->setFocus();
 }
-
-#include "inputdialog.moc"
-

--- a/src/inputdialog.h
+++ b/src/inputdialog.h
@@ -21,7 +21,7 @@
 #define _InputDialog_H_
 
 #include <QtGui>
-#include <klineedit.h>
+#include <KLineEdit>
 
 enum DialogType       {dialogMoney=0, dialogMeasures=1, dialogTicket=3, dialogCashOut=4, dialogStockCorrection=5, dialogTerminalNum=6, dialogSpecialOrder=7, dialogTicketMsg=8, dialogCurrency=9 };
 

--- a/src/iotpos.cpp
+++ b/src/iotpos.cpp
@@ -816,5 +816,3 @@ void iotpos::salir()
     kapp->quit();
   }
 }
-
-#include "iotpos.moc"

--- a/src/iotpos.cpp
+++ b/src/iotpos.cpp
@@ -23,17 +23,17 @@
 #include "enums.h"
 
 #include "iconutils.h"
-#include <kmenubar.h>
-#include <kstatusbar.h>
-#include <kconfigdialog.h>
+#include <QMenuBar>
+#include <QStatusBar>
+#include <KConfigDialog>
 #include <QFileDialog>
-#include <kactioncollection.h>
+#include <KActionCollection>
 #include <QAction>
-#include <kstandardaction.h>
+#include <KStandardAction>
 #include <QLocale>
 #include <KNotification>
 
-#include <ktoolbar.h>
+#include <KToolBar>
 
 
 #include <QListWidgetItem>

--- a/src/iotpos.cpp
+++ b/src/iotpos.cpp
@@ -30,6 +30,7 @@
 #include <KActionCollection>
 #include <QAction>
 #include <KStandardAction>
+#include <KLocalizedString>
 #include <QLocale>
 #include <KNotification>
 
@@ -677,18 +678,18 @@ void iotpos::enableUi()
 
 void iotpos::disableConfig()
 {
-  QAction *actPref = actionCollection()->action(KStandardAction::stdName(KStandardAction::Preferences));
+  QAction *actPref = actionCollection()->action(KStandardAction::name(KStandardAction::Preferences));
   actPref->setDisabled(true);
-  QAction *actQuit = actionCollection()->action(KStandardAction::stdName(KStandardAction::Quit));
+  QAction *actQuit = actionCollection()->action(KStandardAction::name(KStandardAction::Quit));
   //FIXME: esto no es muy bueno en produccion..
   if (!Settings::allowAnyUserToQuit()) actQuit->setDisabled(true);
 }
 
 void iotpos::enableConfig()
 {
-  QAction *actPref = actionCollection()->action(KStandardAction::stdName(KStandardAction::Preferences));
+  QAction *actPref = actionCollection()->action(KStandardAction::name(KStandardAction::Preferences));
   actPref->setEnabled(true);
-  QAction *actQuit = actionCollection()->action(KStandardAction::stdName(KStandardAction::Quit));
+  QAction *actQuit = actionCollection()->action(KStandardAction::name(KStandardAction::Quit));
   actQuit->setEnabled(true);
 
   QAction *actSop = actionCollection()->action("startOperation");
@@ -741,7 +742,7 @@ void iotpos::updateClock()
 void iotpos::updateDate()
 {
   QDate dt = QDate::currentDate();
-  labelDate->setText(LocaleUtils::formatDate(dt));
+  labelDate->setText(LocaleUtils::formatDate(dt, QLocale::ShortFormat));
 }
 
 void iotpos::updateUserName()
@@ -783,8 +784,7 @@ bool iotpos::queryClose()
   //Check if the gridview is hidden, to do not save its 0 size values.
   if ( ss1 >= 50) Settings::setSplitterSizes(m_view->getTheSplitterSizes());
   if ( ss2 >= 50) Settings::setGridSplitterSizes(m_view->getTheGridSplitterSizes());
-  //FIXED Settings::writeConfig();
-  Settings::self()->writeConfig();
+  Settings::self()->save();
   //Close only by admin user. or ask for password??
   if (Settings::allowAnyUserToQuit())
   {
@@ -813,6 +813,6 @@ void iotpos::salir()
 {
   if (queryClose()) {
     qDebug()<<"===EXIT IOTPOS AT "<<QDateTime::currentDateTime().toString();
-    kapp->quit();
+    QApplication::quit();
   }
 }

--- a/src/iotpos.h
+++ b/src/iotpos.h
@@ -25,7 +25,7 @@
 #include <config.h>
 #endif
 
-#include <kxmlguiwindow.h>
+#include <KXmlGuiWindow>
 
 #include "ui_prefs_base.h"
 #include "ui_store_data.h"

--- a/src/iotposview.cpp
+++ b/src/iotposview.cpp
@@ -77,10 +77,10 @@
 #include <QMessageBox>
 #include <QLocale>
 
-#include <kplotobject.h>
-#include <kplotwidget.h>
-#include <kplotaxis.h>
-#include <kplotpoint.h>
+#include <KPlotObject>
+#include <KPlotWidget>
+#include <KPlotAxis>
+#include <KPlotPoint>
 
 
 #include <KLocalizedString>

--- a/src/iotposview.cpp
+++ b/src/iotposview.cpp
@@ -86,7 +86,7 @@
 #include <KLocalizedString>
 #include "iconutils.h"
 #include "pathutils.h"
-#include <kmessagebox.h>
+#include <KMessageBox>
 #include <KNotification>
 #include <QFile>
 #include <iostream>

--- a/src/iotposview.cpp
+++ b/src/iotposview.cpp
@@ -6709,9 +6709,6 @@ BasketPriceSummary iotposView::recalculateBasket(double oDiscountMoney) {
 
     return summary;
 }
-
-#include "iotposview.moc"
-
 void iotposView::on_rbFilterByCategory_clicked()
 {
     ui_mainview.editItemCode->clear();

--- a/src/iotposview.cpp
+++ b/src/iotposview.cpp
@@ -53,6 +53,9 @@
 // #include "printers/sp500.h"
 
 #include <QPrinter>
+#include <QMarginsF>
+#include <QPageLayout>
+#include <QPageSize>
 #include <QPrintDialog>
 #include <QWidget>
 #include <QStringList>
@@ -60,6 +63,7 @@
 #include <QColor>
 #include <QPixmap>
 #include <QHeaderView>
+#include <QCompleter>
 #include <QTableWidget>
 #include <QTableWidgetItem>
 #include <QTextCodec>
@@ -605,7 +609,7 @@ void iotposView::setUpTable()
   ui_mainview.tableWidget->horizontalHeader()->setFixedHeight(24);
   int x = (QApplication::desktop()->width());
   if (x < 600){
-   ui_mainview.tableWidget->horizontalHeader()->setResizeMode(QHeaderView::Interactive);
+   ui_mainview.tableWidget->horizontalHeader()->setSectionResizeMode(QHeaderView::Interactive);
    ui_mainview.tableWidget->horizontalHeader()->resizeSection(colQty, (portion/1.5));  //QTY
    ui_mainview.tableWidget->horizontalHeader()->resizeSection(colUnits, (portion/3)+20);//UNITS
    ui_mainview.tableWidget->horizontalHeader()->resizeSection(colDesc, (portion*2.75)); //DESCRIPTION
@@ -615,7 +619,7 @@ void iotposView::setUpTable()
    ui_mainview.tableWidget->hideColumn(5);
   }
   else{
-      ui_mainview.tableWidget->horizontalHeader()->setResizeMode(QHeaderView::Interactive);
+      ui_mainview.tableWidget->horizontalHeader()->setSectionResizeMode(QHeaderView::Interactive);
       ui_mainview.tableWidget->horizontalHeader()->resizeSection(colCode, portion-20); //BAR CODE
       ui_mainview.tableWidget->horizontalHeader()->resizeSection(colQty, (portion/3)+10);  //QTY
       ui_mainview.tableWidget->horizontalHeader()->resizeSection(colUnits, (portion/3)+10);//UNITS
@@ -636,7 +640,7 @@ void iotposView::resizeSearchTable()
     QSize tableSize = ui_mainview.tableSearch->size();
 
     int portion = tableSize.width()/7;
-    ui_mainview.tableSearch->horizontalHeader()->setResizeMode(QHeaderView::Interactive);
+    ui_mainview.tableSearch->horizontalHeader()->setSectionResizeMode(QHeaderView::Interactive);
     ui_mainview.tableSearch->horizontalHeader()->resizeSection(0, portion*1); //QTY
     ui_mainview.tableSearch->horizontalHeader()->resizeSection(1, portion*2); //UNIT
     ui_mainview.tableSearch->horizontalHeader()->resizeSection(2, portion*3); //DESCRIPTION
@@ -652,7 +656,7 @@ void iotposView::resizeSearchTableSmall()
     QSize tableSize = ui_mainview.tableSearch->size();
 
     int portion = tableSize.width()/5;
-    ui_mainview.tableSearch->horizontalHeader()->setResizeMode(QHeaderView::Interactive);
+    ui_mainview.tableSearch->horizontalHeader()->setSectionResizeMode(QHeaderView::Interactive);
     ui_mainview.tableSearch->horizontalHeader()->resizeSection(0, portion*1); //QTY
     ui_mainview.tableSearch->horizontalHeader()->resizeSection(1, portion*2); //UNIT
     ui_mainview.tableSearch->horizontalHeader()->resizeSection(2, portion*3); //DESCRIPTION
@@ -1168,7 +1172,8 @@ void iotposView::login()
   if (!db.isOpen()) {
     qDebug()<<"(login): Still unable to open connection to database....";
     QString msg = i18n("Could not connect to database, please press 'login' button again to raise a database configuration.");
-    KNotification *notify = new KNotification(QStringLiteral("databaseError"), this);
+    KNotification *notify = new KNotification(QStringLiteral("databaseError"));
+    notify->setWidget(this);
     notify->setTitle(i18n("Error"));
     notify->setText(msg);
     notify->setIconName(QStringLiteral("dialog-error"));
@@ -1679,7 +1684,8 @@ void iotposView::insertItem(QString code)
   }
 
   if ( !specialOrders.isEmpty() ) {
-    KNotification *notify = new KNotification("information", this);
+    KNotification *notify = new KNotification("information");
+    notify->setWidget(this);
     notify->setText(i18n("Only Special Orders can be added. Please finish the current special order before adding any other product."));
     QPixmap pixmap = themedPixmap("dialog-information",32);
     notify->setPixmap(pixmap);
@@ -1690,7 +1696,8 @@ void iotposView::insertItem(QString code)
 
 qDebug()<< __FUNCTION__ <<" doNotAddMoreItems = "<<doNotAddMoreItems;
 if ( doNotAddMoreItems ) { //only for reservations
-    KNotification *notify = new KNotification("information", this);
+    KNotification *notify = new KNotification("information");
+    notify->setWidget(this);
     notify->setText(i18n("Cannot Add more items to the Reservation."));
     QPixmap pixmap = themedPixmap("dialog-information",32);
     notify->setPixmap(pixmap);
@@ -2142,7 +2149,8 @@ int iotposView::doInsertItem(QString itemCode, QString itemDesc, double itemQty,
 void iotposView::deleteSelectedItem()
 {
   if (startingReservation || finishingReservation) {
-      KNotification *notify = new KNotification("information", this);
+      KNotification *notify = new KNotification("information");
+      notify->setWidget(this);
       notify->setText(i18n("Cannot delete items from a reservation."));
       QPixmap pixmap = themedPixmap("dialog-information",32);
       notify->setPixmap(pixmap);
@@ -3036,7 +3044,8 @@ void iotposView::finishCurrentTransaction()
     }
     else {
        //KMessageBox::error(this, i18n("The Drawer is not initialized, please start operation first."), i18n("Error") );
-      KNotification *notify = new KNotification("information", this);
+      KNotification *notify = new KNotification("information");
+      notify->setWidget(this);
       notify->setText(i18n("The Drawer is not initialized, please start operation first."));
       QPixmap pixmap = themedPixmap("dialog-information",32);
       notify->setPixmap(pixmap);
@@ -3129,7 +3138,9 @@ void iotposView::finishCurrentTransaction()
     //Check level of cash in drawer
     if (drawer->getAvailableInCash() < Settings::cashMinLevel() && Settings::displayWarningOnLowCash()) {
       
-      KNotification *notify = new KNotification("information", this);
+      KNotification *notify = new KNotification("information");
+      
+      notify->setWidget(this);
       notify->setText(i18n("Cash level in drawer is low."));
       QPixmap pixmap = themedPixmap("dialog-warning",32); //NOTE: This does not works
       notify->setPixmap(pixmap);
@@ -3158,7 +3169,8 @@ void iotposView::printTicket(TicketInfo ticket)
 {
   if (ticket.total == 0 && !Settings::printZeroTicket()) {
     freezeWidgets();
-    KNotification *notify = new KNotification("information", this);
+    KNotification *notify = new KNotification("information");
+    notify->setWidget(this);
     notify->setText(i18n("The ticket was not printed because it is ZERO in the amount to pay. Just to save trees."));
     QPixmap pixmap = themedPixmap("dialog-error",32);
     notify->setPixmap(pixmap);
@@ -3452,8 +3464,8 @@ void iotposView::printTicket(TicketInfo ticket)
       printer.setFullPage( true );
 
       //This is lost when the user chooses a printer. Because the printer overrides the paper sizes.
-      printer.setPageMargins(0,0,0,0,QPrinter::Millimeter);
-      //TODO:Nueva impresora. printer.setPaperSize(QSizeF(72,200), QPrinter::Millimeter); //setting small ticket paper size. 72mm x 200mm
+      printer.setPageMargins(QMarginsF(), QPageLayout::Millimeter);
+      //TODO:Nueva impresora. printer.setPageSize(QPageSize(QSizeF(72,200), QPageSize::Millimeter)); //setting small ticket paper size. 72mm x 200mm
       //NOTE: Ojo: si se hace click en el boton "Properties" del dialogo de Imprimir, aunque se presione "cancel", el "PAGE" se pone como 204mm
       //NOTE: El calculo del tamano de fuente no es correcta para papeles mayores a 72mm de anchos.
 
@@ -3465,8 +3477,8 @@ ptInfo.totDisc = discMoney;
 ptInfo.tDisc = LocaleUtils::formatMoney(-discMoney, QString(), 2);
       if ( printDialog.exec() ) {
         //this overrides what the user chooses if he does change sizes and margins.
-        printer.setPageMargins(0,0,0,0,QPrinter::Millimeter);
-        //printer.setPaperSize(QSizeF(72,200), QPrinter::Millimeter); //setting small ticket paper size. 72mm x 200mm
+        printer.setPageMargins(QMarginsF(), QPageLayout::Millimeter);
+        //printer.setPageSize(QPageSize(QSizeF(72,200), QPageSize::Millimeter)); //setting small ticket paper size. 72mm x 200mm
         //TODO: Set Copies: printer.setCopyCount(2); //NOTE:Introduced in Qt 4.7 --WARNING-- See also setCollateCopies()
         PrintCUPS::printSmallTicket(ptInfo, printer);
 
@@ -3479,7 +3491,7 @@ ptInfo.tDisc = LocaleUtils::formatMoney(-discMoney, QString(), 2);
         qDebug()<<fn;
 
         printer.setOutputFileName(fn);
-        printer.setPageMargins(0,0,0,0,QPrinter::Millimeter);
+        printer.setPageMargins(QMarginsF(), QPageLayout::Millimeter);
 
         PrintCUPS::printSmallTicket(ptInfo, printer);
       } else {
@@ -3495,8 +3507,8 @@ ptInfo.tDisc = LocaleUtils::formatMoney(-discMoney, QString(), 2);
           qDebug()<<fn;
 
           printer.setOutputFileName(fn);
-          printer.setPageMargins(0,0,0,0,QPrinter::Millimeter);
-          printer.setPaperSize(QSizeF(72,200), QPrinter::Millimeter); //setting small ticket paper size. 72mm x 200mm
+          printer.setPageMargins(QMarginsF(), QPageLayout::Millimeter);
+          printer.setPageSize(QPageSize(QSizeF(72,200), QPageSize::Millimeter)); //setting small ticket paper size. 72mm x 200mm
 
           PrintCUPS::printSmallTicket(ptInfo, printer);
       }
@@ -3762,7 +3774,8 @@ void iotposView::cancelTransaction(qulonglong transactionNumber)
   //Check if payment was with cash.
   //FIXME: Allow card payments to be cancelled!!! DIC 2009
   if (tinfo.paymethod != 1 ) {
-    KNotification *notify = new KNotification("information", this);
+    KNotification *notify = new KNotification("information");
+    notify->setWidget(this);
     notify->setText(i18n("The ticket cannot be cancelled because it was paid with a credit/debit card."));
     QPixmap pixmap = themedPixmap("dialog-error",32);
     notify->setPixmap(pixmap);
@@ -3784,7 +3797,8 @@ void iotposView::cancelTransaction(qulonglong transactionNumber)
           if (Settings::openDrawer() && Settings::smallTicketDotMatrix() && Settings::printTicket()) drawer->open();
         }
         //Inform to the user.
-        KNotification *notify = new KNotification("information", this);
+        KNotification *notify = new KNotification("information");
+        notify->setWidget(this);
         notify->setText(i18n("The ticket was sucessfully cancelled."));
         QPixmap pixmap = themedPixmap("dialog-error",32);
         notify->setPixmap(pixmap);
@@ -3796,7 +3810,8 @@ void iotposView::cancelTransaction(qulonglong transactionNumber)
     else { //myDB->cancelTransaction() returned some error...
       qDebug()<<"Not cancelled!";
       if (!transToCancelIsInProgress) {
-        KNotification *notify = new KNotification("information", this);
+        KNotification *notify = new KNotification("information");
+        notify->setWidget(this);
         notify->setText(i18n("Error cancelling ticket: %1",myDb->lastError()));
         QPixmap pixmap = themedPixmap("dialog-error",32);
         notify->setPixmap(pixmap);
@@ -3825,7 +3840,9 @@ void iotposView::cancelTransaction(qulonglong transactionNumber)
     else
       msg = i18n("Ticket to cancel does not exists!");
 
-    KNotification *notify = new KNotification("information", this);
+    KNotification *notify = new KNotification("information");
+
+    notify->setWidget(this);
     notify->setText(msg);
     QPixmap pixmap = themedPixmap("dialog-error",32);
     notify->setPixmap(pixmap);
@@ -4196,8 +4213,8 @@ void iotposView::corteDeCaja()
       QPrintDialog printDialog( &printer );
       printDialog.setWindowTitle(i18n("Print Balance"));
       if ( printDialog.exec() ) {
-        printer.setPageMargins(0,0,0,0,QPrinter::Millimeter);
-        //TODO:Nueva impresora. printer.setPaperSize(QSizeF(72,200), QPrinter::Millimeter); //setting small ticket paper size. 72mm x 200mm
+        printer.setPageMargins(QMarginsF(), QPageLayout::Millimeter);
+        //TODO:Nueva impresora. printer.setPageSize(QPageSize(QSizeF(72,200), QPageSize::Millimeter)); //setting small ticket paper size. 72mm x 200mm
         //NOTE: Ojo: si se hace click en el boton "Properties" del dialogo de Imprimir, aunque se presione "cancel", el "PAGE" se pone como 204mm
         //NOTE: El calculo del tamano de fuente no es correcta para papeles mayores a 72mm de anchos.
 
@@ -4216,8 +4233,8 @@ void iotposView::corteDeCaja()
           qDebug()<<fn;
 
           printer.setOutputFileName(fn);
-          printer.setPageMargins(0,0,0,0,QPrinter::Millimeter);
-          printer.setPaperSize(QSizeF(72,200), QPrinter::Millimeter); //setting small ticket paper size. 72mm x 200mm
+          printer.setPageMargins(QMarginsF(), QPageLayout::Millimeter);
+          printer.setPageSize(QPageSize(QSizeF(72,200), QPageSize::Millimeter)); //setting small ticket paper size. 72mm x 200mm
 
           PrintCUPS::printSmallBalance(pbInfo, printer);
       }
@@ -4390,8 +4407,8 @@ if (Settings::printZeroTicket()) {
           qDebug()<<fn;
 
           printer.setOutputFileName(fn);
-          printer.setPageMargins(0,0,0,0,QPrinter::Millimeter);
-          printer.setPaperSize(QSizeF(72,200), QPrinter::Millimeter); //setting small ticket paper size. 72mm x 200mm
+          printer.setPageMargins(QMarginsF(), QPageLayout::Millimeter);
+          printer.setPageSize(QPageSize(QSizeF(72,200), QPageSize::Millimeter)); //setting small ticket paper size. 72mm x 200mm
 
           PrintCUPS::printSmallEndOfDay(pdInfo, printer);
       }
@@ -4849,7 +4866,7 @@ void iotposView::setupTicketView()
   historyTicketsModel->select();
   QSize tableSize = ui_mainview.ticketView->size();
   int portion = tableSize.width()/7;
-  ui_mainview.ticketView->horizontalHeader()->setResizeMode(QHeaderView::Interactive);
+  ui_mainview.ticketView->horizontalHeader()->setSectionResizeMode(QHeaderView::Interactive);
   ui_mainview.ticketView->horizontalHeader()->resizeSection(historyTicketsModel->fieldIndex("id"), portion);
   ui_mainview.ticketView->horizontalHeader()->resizeSection(historyTicketsModel->fieldIndex("name"), portion);
   ui_mainview.ticketView->horizontalHeader()->resizeSection(historyTicketsModel->fieldIndex("datetime"), portion);
@@ -4896,7 +4913,8 @@ void iotposView::printSelTicket()
     else {
         //show a notification.
         qDebug()<<"No administrator password supplied for reprint ticket";
-        KNotification *notify = new KNotification("information", this);
+        KNotification *notify = new KNotification("information");
+        notify->setWidget(this);
         notify->setText(i18n("Reprint ticket cancelled."));
         QPixmap pixmap = themedPixmap("dialog-error",32);
         notify->setPixmap(pixmap);
@@ -5057,10 +5075,13 @@ void iotposView::cashOut()
 
   if (doit) {
     double max = drawer->getAvailableInCash();
-    if (!max>0) {
+    if (max <= 0) {
       
 
-      KNotification *notify = new KNotification("information", this);
+      KNotification *notify = new KNotification("information");
+      
+
+      notify->setWidget(this);
       notify->setText(i18n("Cash not available at drawer!"));
       QPixmap pixmap = themedPixmap("dialog-error",32);
       notify->setPixmap(pixmap);
@@ -5142,7 +5163,8 @@ void iotposView::cashIn()
 void iotposView::cashAvailable()
 {
   double available = drawer->getAvailableInCash();
-  KNotification *notify = new KNotification("information", this);
+  KNotification *notify = new KNotification("information");
+  notify->setWidget(this);
   notify->setText(i18n("There are <b> %1 in cash </b> available at the drawer.", LocaleUtils::formatMoney(available)));
   QPixmap pixmap = themedPixmap("dialog-information",32);
   notify->setPixmap(pixmap);
@@ -5163,7 +5185,8 @@ void iotposView::log(const qulonglong &uid, const QDate &date, const QTime &time
 void iotposView::addSpecialOrder()
 {
   if ( transactionInProgress && (totalSum >0) && specialOrders.isEmpty() ) {
-    KNotification *notify = new KNotification("information", this);
+    KNotification *notify = new KNotification("information");
+    notify->setWidget(this);
     notify->setText(i18n("Please finish the current transaction before creating a special order."));
     QPixmap pixmap = themedPixmap("dialog-information",32);
     notify->setPixmap(pixmap);
@@ -5268,7 +5291,8 @@ void iotposView::specialOrderComplete()
 {
   //first ensure we have no pending transaction
   if ( transactionInProgress && (totalSum >0) ) {
-    KNotification *notify = new KNotification("information", this);
+    KNotification *notify = new KNotification("information");
+    notify->setWidget(this);
     notify->setText(i18n("Please finish the current transaction before completing a special order."));
     QPixmap pixmap = themedPixmap("dialog-information",32);
     notify->setPixmap(pixmap);
@@ -5285,7 +5309,8 @@ void iotposView::specialOrderComplete()
     myDb->setDatabase(db);
     QList<SpecialOrderInfo> soList = myDb->getAllSOforSale(tNum);
     if (soList.isEmpty()) {
-      KNotification *notify = new KNotification("information", this);
+      KNotification *notify = new KNotification("information");
+      notify->setWidget(this);
       notify->setText(i18n("The given ticket number does not contains any special order."));
       QPixmap pixmap = themedPixmap("dialog-information",32);
       notify->setPixmap(pixmap);
@@ -5313,7 +5338,8 @@ void iotposView::specialOrderComplete()
           soCompletePayments++;
           myDb->specialOrderSetStatus(soInfo.orderid, stDelivered);
           qDebug()<<"This special order is completeley paid and marked as delivered without emiting a ticket.";
-          KNotification *notify = new KNotification("information", this);
+          KNotification *notify = new KNotification("information");
+          notify->setWidget(this);
           notify->setText(i18n("The special order %1 in ticket %2 is completely paid. Marked as delivered.", soInfo.orderid, soInfo.saleid));
           QPixmap pixmap = themedPixmap("dialog-information",32);
           notify->setPixmap(pixmap);
@@ -5374,7 +5400,8 @@ void iotposView::specialOrderComplete()
     refreshTotalLabel();
 
     if (paidOrders.count()> 1) { // the first is the pre-message
-      KNotification *notify = new KNotification("information", this);
+      KNotification *notify = new KNotification("information");
+      notify->setWidget(this);
       notify->setText(paidOrders.join("\n"));
       QPixmap pixmap = themedPixmap("dialog-information",32);
       notify->setPixmap(pixmap);
@@ -5587,7 +5614,8 @@ void iotposView::suspendSale()
     }
 
     //inform the user
-    KNotification *notify = new KNotification("information", this);
+    KNotification *notify = new KNotification("information");
+    notify->setWidget(this);
     notify->setText(i18n("The sale %1 has been sucessfully suspended.", tmpId));
     QPixmap pixmap = themedPixmap("dialog-information",32);
     notify->setPixmap(pixmap);
@@ -5670,7 +5698,8 @@ void iotposView::resumeSale()
 void iotposView::changeSOStatus()
 {
   if ( transactionInProgress && (totalSum >0) ) {
-    KNotification *notify = new KNotification("information", this);
+    KNotification *notify = new KNotification("information");
+    notify->setWidget(this);
     notify->setText(i18n("Please finish the current transaction before changing state for a special order."));
     QPixmap pixmap = themedPixmap("dialog-information",32);
     notify->setPixmap(pixmap);
@@ -5874,7 +5903,8 @@ void iotposView::reserveItems()
 
         if (rInfo.payment <= 0) {
             //TODO: Replace this notify with a mibitLineEdit->VIBRAR, y mibitTip
-            KNotification *notify = new KNotification("information", this);
+            KNotification *notify = new KNotification("information");
+            notify->setWidget(this);
             notify->setText(i18n("Please Enter the reservation Amount in the Payment Amount and try again."));
             QPixmap pixmap = themedPixmap("dialog-information",32);
             notify->setPixmap(pixmap);
@@ -5987,11 +6017,12 @@ void iotposView::reserveItems()
         ticket.datetime = QDateTime::currentDateTime(); //NOTE:Reservations are not DATE CHANGEABLE.
 
         QString realSubtotal;
-        if (Settings::addTax())
+        if (Settings::addTax()) {
             realSubtotal = LocaleUtils::formatMoney(subTotalSum-discMoney+pDiscounts, QString(), 2);
-        else
+        } else {
             realSubtotal = LocaleUtils::formatMoney(subTotalSum-totalTax+discMoney+pDiscounts, QString(), 2); //FIXME: es +discMoney o -discMoney??
-            qDebug()<<"\n********** Total Taxes:"<<totalTax<<" total Discount:"<<discMoney<<" Prod Discounts:"<<pDiscounts;
+        }
+        qDebug()<<"\n********** Total Taxes:"<<totalTax<<" total Discount:"<<discMoney<<" Prod Discounts:"<<pDiscounts;
 
         ticket.number = currentTransaction;
         ticket.subTotal = realSubtotal; //This is the subtotal-taxes-discount
@@ -6027,7 +6058,8 @@ void iotposView::reserveItems()
 
     } else {
         //Cannot reserve empty product list!
-        KNotification *notify = new KNotification("information", this);
+        KNotification *notify = new KNotification("information");
+        notify->setWidget(this);
         notify->setText(i18n("Cannot make a reservation, no products on the list. Special Orders are not considered."));
         QPixmap pixmap = themedPixmap("dialog-information",32);
         notify->setPixmap(pixmap);
@@ -6052,7 +6084,8 @@ void iotposView::suspendReservation()
         // clear widgets
         startAgain();
         //inform the user
-        KNotification *notify = new KNotification("information", this);
+        KNotification *notify = new KNotification("information");
+        notify->setWidget(this);
         notify->setText(i18n("The sale %1 has been sucessfully reserved.", tmpId));
         QPixmap pixmap = themedPixmap("dialog-information",32);
         notify->setPixmap(pixmap);
@@ -6158,7 +6191,8 @@ void iotposView::addReservationPayment()
 {
     //This is used to add payments to a reservation without totally paying it.
     if (finishingReservation || startingReservation) {
-        KNotification *notify = new KNotification("information", this);
+        KNotification *notify = new KNotification("information");
+        notify->setWidget(this);
         notify->setText(i18n("You need to finish or suspend the current sale or reservation before adding a payment for a reservation."));
         QPixmap pixmap = themedPixmap("dialog-information",32);
         notify->setPixmap(pixmap);
@@ -6470,14 +6504,14 @@ void iotposView::printCreditReport()
         if (Settings::smallTicketCUPS()) {
             QPrinter printer(QPrinter::HighResolution);
             printer.setFullPage( true );
-            printer.setPageMargins(0,0,0,0,QPrinter::Millimeter);
+            printer.setPageMargins(QMarginsF(), QPageLayout::Millimeter);
 
             qDebug()<<"-Paper Width: "<<printer.widthMM()<<"mm"<<"; Page Width: "<<printer.width();
             //NOTE: I dont know why the printer reports a paper width of 210mm (that is a A4/Letter width).
             //      Why, why?.. even the default printer is the TSP800.
 
             if (printer.widthMM() > 150)
-                printer.setPaperSize(QSizeF(104,110), QPrinter::Millimeter); // Resetting to 104mm (4 inches) paper.
+                printer.setPageSize(QPageSize(QSizeF(104,110), QPageSize::Millimeter)); // Resetting to 104mm (4 inches) paper.
 
             qDebug()<<"+Paper Width: "<<printer.widthMM()<<"mm"<<"; Page Width: "<<printer.width();
 
@@ -6492,15 +6526,15 @@ void iotposView::printCreditReport()
             qDebug()<<" Exporting credit report to:"<<fn;
             printer.setOutputFileName(fn);
             printer.setOutputFormat(QPrinter::PdfFormat);
-            printer.setPageMargins(0,0,0,0,QPrinter::Millimeter);
-            printer.setPaperSize(QSizeF(72,200), QPrinter::Millimeter);
+            printer.setPageMargins(QMarginsF(), QPageLayout::Millimeter);
+            printer.setPageSize(QPageSize(QSizeF(72,200), QPageSize::Millimeter));
             ui_mainview.creditContent->print(&printer);
         }
          else if (Settings::printZeroTicket()) {
         // Send to spool file
 		 QPrinter printer(QPrinter::HighResolution);
             printer.setFullPage( true );
-            printer.setPageMargins(0,0,0,0,QPrinter::Millimeter);
+            printer.setPageMargins(QMarginsF(), QPageLayout::Millimeter);
             qDebug()<<"-Paper Widt: "<<printer.widthMM()<<"mm"<<"; Page Widt: "<<printer.width();
 			ui_mainview.creditContent->print(&printer);
 
@@ -6511,7 +6545,7 @@ void iotposView::printCreditReport()
 		  // TODO: GET DIALOG BOX UP.
 		 QPrinter printer(QPrinter::HighResolution);
             printer.setFullPage( true );
-            printer.setPageMargins(0,0,0,0,QPrinter::Millimeter);
+            printer.setPageMargins(QMarginsF(), QPageLayout::Millimeter);
             qDebug()<<"-Paper Widt: "<<printer.widthMM()<<"mm"<<"; Page Widt: "<<printer.width();
 		  ui_mainview.creditContent->print(&printer);
 

--- a/src/loginwindow.cpp
+++ b/src/loginwindow.cpp
@@ -413,5 +413,3 @@ void LoginWindow::reloadUsers()
 {
     uHash = getUsers();
 }
-
-#include "loginwindow.moc"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,7 +51,7 @@ int main(int argc, char **argv)
         i18n("IotPOS"),
         QString::fromLatin1(version),
         i18n(description),
-        KAboutData::License_GPL,
+        KAboutLicense::GPL,
         i18n("(C) 2013-2017 Hiram Ronquillo Villarreal"),
         QString(),
         QString(),

--- a/src/pricechecker.cpp
+++ b/src/pricechecker.cpp
@@ -113,6 +113,3 @@ void PriceChecker::setDb(QSqlDatabase database)
 {
   myDb->setDatabase(database);
 }
-
-
-#include "pricechecker.moc"

--- a/src/productdelegate.cpp
+++ b/src/productdelegate.cpp
@@ -194,5 +194,3 @@ QSize ProductDelegate::sizeHint(const QStyleOptionViewItem &optionUnused,
 {
   return QSize(150,150);
 }
-
-#include "productdelegate.moc"

--- a/src/soselector.cpp
+++ b/src/soselector.cpp
@@ -201,7 +201,7 @@ void SOSelector::setupModel()
   ui->tableWidget->resizeColumnsToContents();
 
   //changed here because when assigning the date to the datePicker this signal was causing to apply the filter which caused a crash due to that at such time the model was not set up.
-  connect( ui->datePicker, SIGNAL(changed(QDate)), SLOT(applyFilter()) );
+  connect( ui->datePicker, SIGNAL(dateChanged(QDate)), SLOT(applyFilter()) );
 }
 
 void SOSelector::setDb(QSqlDatabase database)

--- a/src/sostatus.cpp
+++ b/src/sostatus.cpp
@@ -196,7 +196,7 @@ void SOStatus::setupModel()
   ui->tableWidget->resizeColumnsToContents();
 
   //changed here because when assigning the date to the datePicker this signal was causing to apply the filter which caused a crash due to that at such time the model was not set up.
-  connect( ui->datePicker, SIGNAL(changed(QDate)), SLOT(applyFilter()) );
+  connect( ui->datePicker, SIGNAL(dateChanged(QDate)), SLOT(applyFilter()) );
 }
 
 void SOStatus::setDb(QSqlDatabase database)

--- a/src/specialordereditor.cpp
+++ b/src/specialordereditor.cpp
@@ -80,7 +80,7 @@ SpecialOrderEditor::SpecialOrderEditor( QWidget *parent, bool newOne )
     connect( ui->btnRemove, SIGNAL(clicked()), SLOT(removeItem()) );
     connect( ui->groupView, SIGNAL(itemDoubleClicked(QTableWidgetItem*)), SLOT(itemDoubleClicked(QTableWidgetItem*)) );
 
-    connect( ui->deliveryDT, SIGNAL(valueChanged(QDateTime)), this, SLOT(checkDate(QDateTime)) );
+    connect( ui->deliveryDT, SIGNAL(dateTimeChanged(QDateTime)), this, SLOT(checkDate(QDateTime)) );
 
     connect( ui->editNotes, SIGNAL(textChanged()), SLOT(updateNoteLength()) );
 

--- a/src/specialordereditor.cpp
+++ b/src/specialordereditor.cpp
@@ -652,5 +652,3 @@ void SpecialOrderEditor::updateNoteLength()
     ui->editNotes->moveCursor(QTextCursor::End, QTextCursor::MoveAnchor);
   }
 }
-
-#include "specialordereditor.moc"

--- a/src/ticketpopup.cpp
+++ b/src/ticketpopup.cpp
@@ -103,5 +103,3 @@ void TicketPopup::closeIt()
   emit onTicketPopupClose(); //to let iotstockview unfreeze the widgets
   close();
 }
-
-#include "ticketpopup.moc"

--- a/src/ticketpopup.h
+++ b/src/ticketpopup.h
@@ -43,7 +43,7 @@ class TicketPopup : public QDialog
     void paintEvent(QPaintEvent *e);
 
   public:
-    TicketPopup(QString text="", QPixmap pixmap=0, int timeToClose=1000);
+    TicketPopup(QString text = QString(), QPixmap pixmap = QPixmap(), int timeToClose=1000);
     void setPixmap(QPixmap pixmap) { imagelabel->setPixmap(pixmap); }
     void popup();
     virtual void paint(QPainter *) {}

--- a/src/ui/mainview.ui
+++ b/src/ui/mainview.ui
@@ -3513,7 +3513,7 @@ p, li { white-space: pre-wrap; }
   <customwidget>
    <class>KPlotWidget</class>
    <extends>QFrame</extends>
-   <header>kplotwidget.h</header>
+   <header>KPlotWidget</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/ui/soselector.ui
+++ b/src/ui/soselector.ui
@@ -163,7 +163,7 @@
         </widget>
        </item>
        <item>
-        <widget class="KDateWidget" name="datePicker"/>
+        <widget class="QDateEdit" name="datePicker"/>
        </item>
       </layout>
      </item>
@@ -211,11 +211,6 @@
   </layout>
  </widget>
  <customwidgets>
-  <customwidget>
-   <class>KDateWidget</class>
-   <extends>QWidget</extends>
-   <header>kdatewidget.h</header>
-  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>editSaleId</tabstop>

--- a/src/ui/sostatus.ui
+++ b/src/ui/sostatus.ui
@@ -163,7 +163,7 @@
         </widget>
        </item>
        <item>
-        <widget class="KDateWidget" name="datePicker"/>
+        <widget class="QDateEdit" name="datePicker"/>
        </item>
       </layout>
      </item>
@@ -232,11 +232,6 @@
   </layout>
  </widget>
  <customwidgets>
-  <customwidget>
-   <class>KDateWidget</class>
-   <extends>QWidget</extends>
-   <header>kdatewidget.h</header>
-  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>editSaleId</tabstop>

--- a/src/ui/special_order.ui
+++ b/src/ui/special_order.ui
@@ -207,7 +207,7 @@
        <item row="3" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout_4">
          <item>
-          <widget class="KDateTimeWidget" name="deliveryDT" native="true"/>
+          <widget class="QDateTimeEdit" name="deliveryDT" native="true"/>
          </item>
          <item>
           <widget class="QLabel" name="lblDateError">
@@ -691,11 +691,6 @@ p, li { white-space: pre-wrap; }
    <class>MibitLineEdit</class>
    <extends>QLineEdit</extends>
    <header>../../mibitWidgets/mibitlineedit.h</header>
-  </customwidget>
-  <customwidget>
-   <class>KDateTimeWidget</class>
-   <extends>QWidget</extends>
-   <header>kdatetimewidget.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>


### PR DESCRIPTION
## What changed

- disable CMake `AUTOUIC` because the project already generates every UI header explicitly with `qt5_wrap_ui`
- remove stale manual `.moc` includes from 21 implementation files
- retain `AUTOMOC` so classes declaring `Q_OBJECT` in headers continue to receive generated meta-object code
- replace removed `KDateWidget` and `KDateTimeWidget` UI controls with Qt `QDateEdit` and `QDateTimeEdit`
- update Designer metadata and C++ includes to exported KF5 `KDatePicker` and `KPlotWidget` headers
- declare the directly used KF5 Completion framework for `KLineEdit`
- declare and link Qt5 SVG for the `QSvgWidget`-based custom controls
- replace Qt4-era integer null defaults with valid Qt5 value objects and `nullptr`
- replace removed menu/status wrappers with `QMenuBar`/`QStatusBar` and use exported KF5 headers
- migrate remaining `kapp`, config-save, and standard-action APIs to Qt5/KF5 equivalents
- move application license keys to the KF5 `KAboutLicense` namespace

## Root cause

The global AUTOUIC scanner treated generated `ui_*.h` includes as requests to locate sibling `.ui` files. The actual forms live in per-target `ui/` directories and are already handled by `qt5_wrap_ui`, causing the build to stop at `clienteditor.h`.

The manual `.moc` includes were remnants of the pre-AUTOMOC build and caused warnings because the corresponding `Q_OBJECT` declarations live in headers, not the implementation files.

## Validation

- Raspberry Pi/Linux aarch64 configuration completed before this failure
- confirmed all affected classes declare `Q_OBJECT` in their headers
- verified no manual `.moc` includes remain
- verified `CMAKE_AUTOUIC` is disabled and `CMAKE_AUTOMOC` remains enabled
- audited all Designer custom-widget headers and date-widget signal connections
- verified obsolete date widgets and lowercase plotting/date headers no longer remain
- audited Qt module usage and declared Qt5 SVG for all `QSvgWidget` consumers
- verified no Qt value parameter retains an integer null default
- verified no audited lowercase KDE headers remain
- verified `KStandardAction::name`, `KCoreConfigSkeleton::save`, and `QApplication::quit` replacements

Full compilation is pending another Raspberry Pi build.